### PR TITLE
Updated for latest Rust nightly.

### DIFF
--- a/src/lazy_static.rs
+++ b/src/lazy_static.rs
@@ -84,7 +84,8 @@ macro_rules! lazy_static {
     };
     ($VIS:ident static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
         lazy_static!(MAKE TY $VIS $N);
-        impl Deref<$T> for $N {
+        impl ::std::ops::Deref for $N {
+            type Target = $T;
             fn deref<'a>(&'a self) -> &'a $T {
                 use std::sync::{Once, ONCE_INIT};
                 use std::mem::transmute;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 lazy_static! {
     static ref NUMBER: uint = times_two(3);
-    static ref ARRAY_BOXES: [Box<uint>, ..3] = [box 1, box 2, box 3];
+    static ref ARRAY_BOXES: [Box<uint>; 3] = [box 1, box 2, box 3];
     static ref STRING: String = "hello".to_string();
     static ref HASHMAP: HashMap<uint, &'static str> = {
         let mut m = HashMap::new();


### PR DESCRIPTION
Deref is no longer in the prelude, so it had to be specified using its full
path (thanks to @pczarn for the syntax). Deref's type parameter was replaced
with an associated type, Target.

Replaced [Box<uint>, ..3] with [Box<uint>; 3] because the former syntax is gone.