### PR TITLE
Update for rust nightly (2015-01-06)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,7 @@ git = "https://github.com/Kimundi/lazy-static.rs"
 Using the macro:
 
 ```rust
-#![feature(phase)]
-
-#[phase(plugin)]
+#[macro_use]
 extern crate lazy_static;
 
 use std::collections::HashMap;

--- a/src/lazy_static.rs
+++ b/src/lazy_static.rs
@@ -33,9 +33,7 @@ trait.
 Using the macro:
 
 ```rust
-#![feature(phase)]
-
-#[phase(plugin)]
+#[macro_use]
 extern crate lazy_static;
 
 use std::collections::HashMap;
@@ -72,8 +70,6 @@ define uninitialized `static mut` values.
 
 #![crate_type = "dylib"]
 
-#![feature(macro_rules)]
-
 #[macro_export]
 macro_rules! lazy_static {
     (static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
@@ -96,7 +92,7 @@ macro_rules! lazy_static {
                 unsafe {
                     static mut __static: *const $T = 0 as *const $T;
                     static mut __ONCE: Once = ONCE_INIT;
-                    __ONCE.doit(|| {
+                    __ONCE.call_once(|| {
                         __static = transmute::<Box<$T>, *const $T>(box() ($e));
                     });
                     let static_ref = &*__static;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,4 @@
-#![feature(phase)]
-
-#[phase(plugin)]
+#[macro_use]
 extern crate lazy_static;
 use std::collections::HashMap;
 
@@ -15,6 +13,7 @@ lazy_static! {
         m.insert(2, "ghi");
         m
     };
+    // This *should* triggger warn(dead_code) by design.
     static ref UNUSED: () = ();
 }
 


### PR DESCRIPTION
sync::Once::doit() -> call_once()
phase/plugin is now just #[macro_use]
Added comment to tests to remind self that UNUSED should trigger dead
code warnings, because it's not clear where the dead code warnings come
from when running tests.