### PR TITLE
Fix build errors and some warnings

### DIFF
--- a/src/lazy_static.rs
+++ b/src/lazy_static.rs
@@ -108,6 +108,7 @@ macro_rules! lazy_static {
         #[allow(non_camel_case_types)]
         #[allow(dead_code)]
         pub struct $N {__private_field: ()}
+        #[allow(dead_code)]
         pub static $N: $N = $N {__private_field: ()};
     };
     (MAKE TY PRIV $N:ident) => {
@@ -115,6 +116,7 @@ macro_rules! lazy_static {
         #[allow(non_camel_case_types)]
         #[allow(dead_code)]
         struct $N {__private_field: ()}
+        #[allow(dead_code)]
         static $N: $N = $N {__private_field: ()};
     };
     () => ()

--- a/src/lazy_static.rs
+++ b/src/lazy_static.rs
@@ -93,7 +93,7 @@ macro_rules! lazy_static {
                     static mut __static: *const $T = 0 as *const $T;
                     static mut __ONCE: Once = ONCE_INIT;
                     __ONCE.call_once(|| {
-                        __static = transmute::<Box<$T>, *const $T>(box() ($e));
+                        __static = transmute::<Box<$T>, *const $T>(Box::new(($e)));
                     });
                     let static_ref = &*__static;
                     require_sync(static_ref);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,3 @@
-#![allow(unstable)]
-
 #[macro_use]
 extern crate lazy_static;
 use std::collections::HashMap;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -25,11 +25,11 @@ fn times_two(n: u32) -> u32 {
 
 #[test]
 fn test_basic() {
-    assert_eq!(STRING.as_slice(), "hello");
+    assert_eq!(&STRING[..], "hello");
     assert_eq!(*NUMBER, 6);
     assert!(HASHMAP.get(&1).is_some());
     assert!(HASHMAP.get(&3).is_none());
-    assert_eq!(ARRAY_BOXES.as_slice(), [Box::new(1), Box::new(2), Box::new(3)].as_slice());
+    assert_eq!(&ARRAY_BOXES[..], &[Box::new(1), Box::new(2), Box::new(3)][..]);
 }
 
 #[test]


### PR DESCRIPTION
Hello,

Thanks for writing lazy_static.

* This PR fixes a build error that appeared recently in Rust nightly
* It also cleans up all outstanding warnings, so the project now builds cleanly (as of Rust b0746ff)

If you could review and release quickly, that would be ideal, since the released version doesn't build on current Rust.  The tests pass in any case.

I release all these patches under the MIT license.
