### PR TITLE
Updated tests to work with nightly 1.0.0-beta (9854143cb 2015-04-02)

### DIFF
--- a/src/lazy_static.rs
+++ b/src/lazy_static.rs
@@ -89,11 +89,14 @@ macro_rules! lazy_static {
                 #[inline(always)]
                 fn require_sync<T: Sync>(_: &T) { }
 
+                #[inline(always)]
+                fn initialize() -> Box<$T> { Box::new($e) }
+
                 unsafe {
                     static mut __static: *const $T = 0 as *const $T;
                     static mut __ONCE: Once = ONCE_INIT;
                     __ONCE.call_once(|| {
-                        __static = transmute::<Box<$T>, *const $T>(Box::new(($e)));
+                        __static = transmute::<Box<$T>, *const $T>(initialize());
                     });
                     let static_ref = &*__static;
                     require_sync(static_ref);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -23,11 +23,11 @@ fn times_two(n: u32) -> u32 {
 
 #[test]
 fn test_basic() {
-    assert_eq!(&STRING[..], "hello");
+    assert_eq!(&**STRING, "hello");
     assert_eq!(*NUMBER, 6);
     assert!(HASHMAP.get(&1).is_some());
     assert!(HASHMAP.get(&3).is_none());
-    assert_eq!(&ARRAY_BOXES[..], &[Box::new(1), Box::new(2), Box::new(3)][..]);
+    assert_eq!(&*ARRAY_BOXES, &[Box::new(1), Box::new(2), Box::new(3)]);
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,6 +13,10 @@ lazy_static! {
         m.insert(2, "ghi");
         m
     };
+    // This should not compile if the unsafe is removed.
+    static ref UNSAFE: u32 = unsafe {
+        std::mem::transmute::<i32, u32>(-1)
+    };
     // This *should* triggger warn(dead_code) by design.
     static ref UNUSED: () = ();
 }
@@ -28,6 +32,7 @@ fn test_basic() {
     assert!(HASHMAP.get(&1).is_some());
     assert!(HASHMAP.get(&3).is_none());
     assert_eq!(&*ARRAY_BOXES, &[Box::new(1), Box::new(2), Box::new(3)]);
+    assert_eq!(*UNSAFE, std::u32::MAX);
 }
 
 #[test]


### PR DESCRIPTION
I noticed that lazy-static is running the user initialization code in an unsafe block, which seems wrong. Before I fix that, though, it seems important to be able to run the tests. The changes are minor--just some updates to slicing syntax.

Cheers,
Jesse