### PR TITLE
Use std::intrinsics::unreachable instead of an infinite loop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ The `Deref` implementation uses a hidden static variable that is guarded by a at
 
 */
 
-#![cfg_attr(feature="nightly", feature(const_fn))]
+#![cfg_attr(feature="nightly", feature(const_fn, core_intrinsics))]
 #![crate_type = "dylib"]
 
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ macro_rules! lazy_static {
                         });
                         match *DATA.0.get() {
                             Some(ref x) => x,
-                            None => loop { /* unreachable */ },
+                            None => ::std::intrinsics::unreachable(),
                         }
                     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature="nightly", feature(const_fn))]
+#![cfg_attr(feature="nightly", feature(const_fn, core_intrinsics))]
 
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
This is totally untested. Is Travis-CI configured on this repository?